### PR TITLE
Add reorder API for exercise plan items

### DIFF
--- a/Backend/BusinessServices/ExercisePlanItemService.cs
+++ b/Backend/BusinessServices/ExercisePlanItemService.cs
@@ -51,6 +51,18 @@ namespace FitSync.BusinessServices
             await _repo.SaveChangesAsync();
         }
 
+        public async Task ReorderAsync(IEnumerable<ExercisePlanItemOrderDTO> items)
+        {
+            var list = items.ToList();
+            foreach (var dto in list)
+            {
+                var entity = await GetPlanItemOrThrowAsync(dto.Id);
+                entity.Order = dto.Order;
+            }
+
+            await _repo.SaveChangesAsync();
+        }
+
         private async Task<ExercisePlanItem> GetPlanItemOrThrowAsync(int id)
             => await _repo.GetPlanItemAsync(id)
                ?? throw new KeyNotFoundException($"ExercisePlanItem with id {id} not found.");

--- a/Backend/BusinessServices/Intefaces/IExercisePlanItemService.cs
+++ b/Backend/BusinessServices/Intefaces/IExercisePlanItemService.cs
@@ -9,5 +9,6 @@ namespace FitSync.BusinessServices.Intefaces
         Task<IEnumerable<ExercisePlanItemDTO>> GetAllByPlanAsync(int planId);
         Task<ExercisePlanItemDTO> GetByIdAsync(int id);
         Task UpdateAsync(int id, ExercisePlanItemUpdateDTO dto);
+        Task ReorderAsync(IEnumerable<ExercisePlanItemOrderDTO> items);
     }
 }

--- a/Backend/Controllers/ExercisePlanItemsController.cs
+++ b/Backend/Controllers/ExercisePlanItemsController.cs
@@ -54,5 +54,13 @@ namespace FitSync.Controllers
             await _service.DeleteAsync(id);
             return NoContent();
         }
+
+        // PUT: api/exerciseplanitems/reorder
+        [HttpPut("reorder")]
+        public async Task<IActionResult> Reorder([FromBody] IEnumerable<ExercisePlanItemOrderDTO> items)
+        {
+            await _service.ReorderAsync(items);
+            return NoContent();
+        }
     }
 }

--- a/Backend/DTOs/ExercisePlanItemDTO.cs
+++ b/Backend/DTOs/ExercisePlanItemDTO.cs
@@ -35,4 +35,11 @@
         public string ExerciseName { get; set; } = null!;
         public string PlanName { get; set; } = null!;
     }
+
+    // 6) DTO за промену редоследа
+    public class ExercisePlanItemOrderDTO
+    {
+        public int Id { get; set; }
+        public int Order { get; set; }
+    }
 }

--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -27,3 +27,6 @@ const api = axios.create({
 export default api;
 
 export const getAllPlans = () => api.get('/exerciseplans');
+
+export const reorderPlanItems = (items) =>
+  api.put('/exerciseplanitems/reorder', items);


### PR DESCRIPTION
## Summary
- create `ExercisePlanItemOrderDTO`
- update `IExercisePlanItemService` with `ReorderAsync`
- implement reordering in `ExercisePlanItemService`
- expose `/api/exerciseplanitems/reorder` endpoint
- add JS helper to call reorder API

## Testing
- `dotnet build` *(fails: command not found)*
- `npm run lint` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_686b09c84dac8331b8722215d4e9c114