### PR TITLE
Add drag & drop ordering for plan items

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -14,7 +14,8 @@
     "jwt-decode": "^4.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.3"
+    "react-router-dom": "^7.6.3",
+    "react-beautiful-dnd": "^13.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/Frontend/src/pages/AddPlanItemsPage.jsx
+++ b/Frontend/src/pages/AddPlanItemsPage.jsx
@@ -1,7 +1,12 @@
 // src/pages/AddPlanItemsPage.jsx
 import React, { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import api from '../services/api';
+import {
+  DragDropContext,
+  Droppable,
+  Draggable
+} from 'react-beautiful-dnd';
+import api, { updatePlanItemOrders } from '../services/api';
 import '../styles/pages/addPlanItems.css';
 
 export default function AddPlanItemsPage() {
@@ -61,6 +66,24 @@ export default function AddPlanItemsPage() {
     setFormData(fd => ({ ...fd, [name]: value }));
   };
 
+  const handleDragEnd = async result => {
+    if (!result.destination) return;
+
+    const items = Array.from(planItems);
+    const [moved] = items.splice(result.source.index, 1);
+    items.splice(result.destination.index, 0, moved);
+
+    const reordered = items.map((it, idx) => ({ ...it, order: idx + 1 }));
+
+    setPlanItems(reordered);
+
+    try {
+      await updatePlanItemOrders(reordered.map(({ id, order }) => ({ id, order })));
+    } catch {
+      setError('Failed to update item order');
+    }
+  };
+
   const handleSubmit = async e => {
   e.preventDefault();
   try {
@@ -114,24 +137,41 @@ export default function AddPlanItemsPage() {
       <section className="current-items">
         <h2>Current Plan Items</h2>
         {planItems.length ? (
-          <table className="items-table">
-            <thead>
-              <tr>
-                <th>#</th><th>Exercise</th><th>Sets</th><th>Reps</th><th>Note</th>
-              </tr>
-            </thead>
-            <tbody>
-              {planItems.map(i => (
-                <tr key={i.id}>
-                  <td>{i.order}</td>
-                  <td>{i.exerciseName}</td>
-                  <td>{i.sets}</td>
-                  <td>{i.reps}</td>
-                  <td>{i.note}</td>
+          <DragDropContext onDragEnd={handleDragEnd}>
+            <table className="items-table">
+              <thead>
+                <tr>
+                  <th>#</th><th>Exercise</th><th>Sets</th><th>Reps</th><th>Note</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <Droppable droppableId="planItems">
+                {(provided) => (
+                  <tbody ref={provided.innerRef} {...provided.droppableProps}>
+                    {planItems.map((i, index) => (
+                      <Draggable key={i.id} draggableId={String(i.id)} index={index}>
+                        {(prov, snapshot) => (
+                          <tr
+                            ref={prov.innerRef}
+                            {...prov.draggableProps}
+                            className={snapshot.isDragging ? 'dragging' : ''}
+                          >
+                            <td className="handle-cell" {...prov.dragHandleProps}>
+                              <span className="drag-handle">☰</span> {i.order}
+                            </td>
+                            <td>{i.exerciseName}</td>
+                            <td>{i.sets}</td>
+                            <td>{i.reps}</td>
+                            <td>{i.note}</td>
+                          </tr>
+                        )}
+                      </Draggable>
+                    ))}
+                    {provided.placeholder}
+                  </tbody>
+                )}
+              </Droppable>
+            </table>
+          </DragDropContext>
         ) : (
           <p>No items yet. Click + below to add.</p>
         )}

--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -27,3 +27,7 @@ const api = axios.create({
 export default api;
 
 export const getAllPlans = () => api.get('/exerciseplans');
+
+export const updatePlanItemOrders = (items) =>
+  api.put('/exerciseplanitems/order', items);
+

--- a/Frontend/src/styles/pages/addPlanItems.css
+++ b/Frontend/src/styles/pages/addPlanItems.css
@@ -96,3 +96,14 @@
 .form-actions button:hover {
   opacity: 0.9;
 }
+
+/* Drag and drop */
+.drag-handle {
+  cursor: grab;
+  user-select: none;
+}
+
+.items-table tr.dragging {
+  background: #f0f0f0;
+  opacity: 0.7;
+}


### PR DESCRIPTION
## Summary
- add `react-beautiful-dnd` dependency
- enable drag-drop ordering in AddPlanItemsPage
- persist new item ordering via API helper
- style drag handle and ghost row

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686b09c8b8d8833187a4b39137c45987